### PR TITLE
Update help link for consignments.

### DIFF
--- a/php/cargonizer_example.php
+++ b/php/cargonizer_example.php
@@ -8,7 +8,7 @@ require_once("include/cargonizer.php");
  * _attribs are added to the parent element as attributes (<array_key attrib_key = 'attrib_value'>)
  * 
  * For field values, see Logistra's documentation of API
- * http://www.logistra.no/cargonizer/api/consignments
+ * http://www.logistra.no/api-documentation/12-utviklerinformasjon/16-api-consignments.html
  * 
  */
 


### PR DESCRIPTION
The link in the example points to a page which is not found. Pretty sure this might be the "new" link for the same page.
